### PR TITLE
CODA-301 - Fixed has should contain URL safe characters

### DIFF
--- a/fixedhash/fixedhash.go
+++ b/fixedhash/fixedhash.go
@@ -22,5 +22,5 @@ func FixedHash(length int) (string, error) {
 		return "", err
 	}
 
-	return base64.StdEncoding.EncodeToString(hashSource), nil
+	return base64.URLEncoding.EncodeToString(hashSource), nil
 }


### PR DESCRIPTION
**Business justification:** https://trello.com/c/kOx4Tf1x/302-coda-301-fixed-has-should-contain-url-safe-characters

**Description:** Fixed hashes should contain only URL safe characters.