### PR TITLE
CODA-310 - Fix SMTP address with port in mailer

### DIFF
--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -49,7 +49,7 @@ func (m *Mailer) SendEmail(body string, recipient string) {
 	msg := composeMessage(m.Sender, recipient, body)
 	smtpAuth := smtp.PlainAuth("", m.Sender, m.Password, m.SMTPAuthURL)
 
-	err := smtp.SendMail(m.SMTPPort, smtpAuth, m.Sender, []string{recipient}, []byte(msg))
+	err := smtp.SendMail(m.SMTPAuthURL+":"+m.SMTPPort, smtpAuth, m.Sender, []string{recipient}, []byte(msg))
 
 	if err != nil {
 		logger.Log("error sending email to "+recipient, err)


### PR DESCRIPTION
**Business justification:** https://trello.com/c/Xe2e033D/310-coda-310-fix-smtp-address-with-port-in-mailer

**Description:** When sending an email via SMTP, it should know address with port.